### PR TITLE
Add conversion to seconds for TimeOffset

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ seconds was? Tough luck. NetTime preserves all information in an RFC
 
 ## Caution
 
-*DO NOT USE* NetTime's data types as direct source for time displayed to end
+**Do not use** NetTime's data types as direct source for time displayed to end
 users. Use something like `Foundation.DateFormatter` and follow best practices.
 Never assume you know enough about timezones and/or calendars to format date
 string!

--- a/Sources/NetTime/TimeOffset.swift
+++ b/Sources/NetTime/TimeOffset.swift
@@ -21,6 +21,18 @@ public struct TimeOffset: Equatable {
     public static var zero: TimeOffset {
         return TimeOffset(sign: .plus, hour: 0, minute: 0)!
     }
+
+    public var asSeconds: Int {
+        let factor: Int
+        switch self.sign {
+        case .plus:
+            factor = 1
+        case .minus:
+            factor = -1
+        }
+
+        return factor * Int(self.minute) * 60 + Int(self.hour) * 3600
+    }
 }
 
 extension TimeOffset {

--- a/Tests/NetTimeTests/TimeOffsetTests.swift
+++ b/Tests/NetTimeTests/TimeOffsetTests.swift
@@ -44,4 +44,9 @@ final class TimeOffsetTests: XCTestCase {
             TimeOffset(sign: .minus, hour: 59, minute: 1)
         )
     }
+
+    func testConvertingToSeconds() {
+        XCTAssertEqual(TimeOffset(sign: .minus, hour: 0, minute: 1)?.asSeconds, -60)
+        XCTAssertEqual(TimeOffset(sign: .plus, hour: 1, minute: 0)?.asSeconds, 3600)
+    }
 }


### PR DESCRIPTION
Convert the quantity the offset represents, including its sign, into
seconds.