### PR TITLE
Add static string initializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Each type is capable of serializing and deserializing from strings format
 specified in [RFC 3339][].
 
 ```swift
-if let date = DateTime(rfc3339String: "1979-05-27T00:32:00.999999-07:00") {
-    date.time.secondFraction // [9, 9, 9, 9, 9, 9]
+let date = DateTime(staticRFC3339String: "1979-05-27T00:32:00.999999-07:00")
+// Original representation is preserved. For example:
+date.time.secondFraction // [9, 9, 9, 9, 9, 9]
 
-    // Use it with Foundation:
-    Foundation.Date(timeIntervalSince1970: date.timeIntervalSince1970)
-    Foundation.TimeZone(secondsFromGMT: date.utcOffset.asSeconds)
-}
+// Use it with Foundation:
+Foundation.Date(timeIntervalSince1970: date.timeIntervalSince1970)
+Foundation.TimeZone(secondsFromGMT: date.utcOffset.asSeconds)
 ```
 
 ## Why?

--- a/Sources/NetTime/DateTime.swift
+++ b/Sources/NetTime/DateTime.swift
@@ -17,6 +17,10 @@ extension DateTime {
         self.init(asciiValues: Array(rfc3339String.utf8CString.dropLast()))
     }
 
+    public init(staticRFC3339String string: StaticString) {
+        self.init(rfc3339String: string.description)!
+    }
+
     init?(asciiValues: [Int8]) {
         guard asciiValues.count == 20
             || asciiValues.count == 25

--- a/Sources/NetTime/LocalDate.swift
+++ b/Sources/NetTime/LocalDate.swift
@@ -44,6 +44,10 @@ extension LocalDate {
         self.init(asciiValues: Array(rfc3339String.utf8CString.dropLast()))
     }
 
+    public init(staticRFC3339String string: StaticString) {
+        self.init(rfc3339String: string.description)!
+    }
+
     init?(asciiValues: [Int8]) {
         if asciiValues.count < 10 {
             return nil

--- a/Sources/NetTime/LocalDateTime.swift
+++ b/Sources/NetTime/LocalDateTime.swift
@@ -15,6 +15,10 @@ extension LocalDateTime {
         self.init(asciiValues: Array(rfc3339String.utf8CString.dropLast()))
     }
 
+    public init(staticRFC3339String string: StaticString) {
+        self.init(rfc3339String: string.description)!
+    }
+
     init?(asciiValues: [Int8]) {
         guard asciiValues.count >= 19,
             case let separator = asciiValues[10],

--- a/Sources/NetTime/LocalTime.swift
+++ b/Sources/NetTime/LocalTime.swift
@@ -45,6 +45,10 @@ extension LocalTime {
         self.init(asciiValues: Array(rfc3339String.utf8CString.dropLast()))
     }
 
+    public init(staticRFC3339String string: StaticString) {
+        self.init(rfc3339String: string.description)!
+    }
+
     init?(asciiValues: [Int8]) {
         guard asciiValues.count >= 8, asciiValues[2] == colon && asciiValues[5] == colon else  {
             return nil

--- a/Sources/NetTime/TimeOffset.swift
+++ b/Sources/NetTime/TimeOffset.swift
@@ -40,6 +40,10 @@ extension TimeOffset {
         self.init(asciiValues: Array(rfc3339String.utf8CString.dropLast()))
     }
 
+    public init(staticRFC3339String string: StaticString) {
+        self.init(rfc3339String: string.description)!
+    }
+
     init?(asciiValues: [Int8]) {
         if asciiValues.count == 1, let first = asciiValues.first, first == z || first == Z {
             self.sign = .plus

--- a/Tests/NetTimeTests/DateTimeTests.swift
+++ b/Tests/NetTimeTests/DateTimeTests.swift
@@ -63,26 +63,17 @@ final class DateTimeTests: XCTestCase {
     }
 
     func testConvertingEpochToInterval() {
-        guard let moment = DateTime(rfc3339String: "1970-01-01T00:00:00+00:00") else {
-            XCTFail("Parsing failure")
-            return
-        }
+        let moment = DateTime(staticRFC3339String: "1970-01-01T00:00:00+00:00")
         XCTAssertEqual(moment.timeIntervalSince1970, 0, accuracy: .ulpOfOne)
     }
 
     func testConvertingEpochWithOffsetToInterval() {
-        guard let moment = DateTime(rfc3339String: "1970-01-01T00:01:00+00:01") else {
-            XCTFail("Parsing failure")
-            return
-        }
+        let moment = DateTime(staticRFC3339String: "1970-01-01T00:01:00+00:01")
         XCTAssertEqual(moment.timeIntervalSince1970, 0, accuracy: .ulpOfOne)
     }
 
     func testConvertingMomentToInterval() {
-        guard let moment = DateTime(rfc3339String: "1970-01-01T01:01:00.123+00:01") else {
-            XCTFail("Parsing failure")
-            return
-        }
+        let moment = DateTime(staticRFC3339String: "1970-01-01T01:01:00.123+00:01")
         XCTAssertEqual(moment.timeIntervalSince1970, 3600.123, accuracy: .ulpOfOne)
     }
 }


### PR DESCRIPTION
The idea is let user opt-in with static strings to deserialize. This way they
take responsiblitiy to use a valid input. (Can be enforced by a linter, for
example).