### PR TITLE
Publicize parsers

### DIFF
--- a/Sources/NetTime/DateTime.swift
+++ b/Sources/NetTime/DateTime.swift
@@ -53,7 +53,19 @@ extension DateTime {
         self.init(rfc3339String: string.description)!
     }
 
-    init?(asciiValues: [Int8]) {
+    /// Create a `DateTime` from an [RFC 3339][] timestamp. Initialization will
+    /// fail if the input does not comply with the format specified in
+    /// [RFC 3339][].
+    ///
+    /// [RFC 3339]: https://tools.ietf.org/html/rfc3339
+    ///
+    /// - Parameter rfc3339String: A timestamp conforming to the format
+    ///                            specified in RFC 3339. the format specified
+    ///                            in RFC 3339. The content should be the same
+    ///                            as argument of `init(rfc3339String:)`.
+    ///                            Terminating `0` value from C strings should
+    ///                            be excluded.
+    public init?(asciiValues: [CChar]) {
         guard asciiValues.count == 20
             || asciiValues.count == 25
             || asciiValues.count > 26,

--- a/Sources/NetTime/LocalDate.swift
+++ b/Sources/NetTime/LocalDate.swift
@@ -82,7 +82,18 @@ extension LocalDate {
         self.init(rfc3339String: string.description)!
     }
 
-    init?(asciiValues: [Int8]) {
+    /// Create a `LocalDate` from an date segement of an [RFC 3339][] timestamp.
+    /// Initialization will fail if the input does not comply with the format
+    /// specified in [RFC 3339][].
+    ///
+    /// [RFC 3339]: https://tools.ietf.org/html/rfc3339
+    ///
+    /// - Parameter rfc3339String: The date potion of a timestamp conforming to
+    ///                            the format specified in RFC 3339. The content
+    ///                            should be the same as argument of
+    ///                            `init(rfc3339String:)`. Terminating `0` value
+    ///                            from C strings should be excluded.
+    public init?(asciiValues: [CChar]) {
         if asciiValues.count < 10 {
             return nil
         }

--- a/Sources/NetTime/LocalDateTime.swift
+++ b/Sources/NetTime/LocalDateTime.swift
@@ -49,7 +49,19 @@ extension LocalDateTime {
         self.init(rfc3339String: string.description)!
     }
 
-    init?(asciiValues: [Int8]) {
+    /// Create a `LocalDateTime` from an [RFC 3339][] timestamp. Initialization
+    /// will /// fail if the input does not comply with the format specified in
+    /// [RFC 3339][]. Time offset will be ignored.
+    ///
+    /// [RFC 3339]: https://tools.ietf.org/html/rfc3339
+    ///
+    /// - Parameter rfc3339String: A timestamp conforming to the format
+    ///                            specified in RFC 3339. the format specified
+    ///                            in RFC 3339. The content should be the same
+    ///                            as argument of `init(rfc3339String:)`.
+    ///                            Terminating `0` value from C strings should
+    ///                            be excluded.
+    public init?(asciiValues: [CChar]) {
         guard asciiValues.count >= 19,
             case let separator = asciiValues[10],
             (separator == T || separator == t || separator == space),

--- a/Sources/NetTime/LocalTime.swift
+++ b/Sources/NetTime/LocalTime.swift
@@ -80,7 +80,18 @@ extension LocalTime {
         self.init(rfc3339String: string.description)!
     }
 
-    init?(asciiValues: [Int8]) {
+    /// Create a `LocalTime` from an time segement of an [RFC 3339][] timestamp.
+    /// Initialization will fail if the input does not comply with the format
+    /// specified in [RFC 3339][].
+    ///
+    /// [RFC 3339]: https://tools.ietf.org/html/rfc3339
+    ///
+    /// - Parameter rfc3339String: The time potion of a timestamp conforming to
+    ///                            the format specified in RFC 3339. The content
+    ///                            should be the same as argument of
+    ///                            `init(rfc3339String:)`. Terminating `0` value
+    ///                            from C strings should be excluded.
+    public init?(asciiValues: [CChar]) {
         guard asciiValues.count >= 8, asciiValues[2] == colon && asciiValues[5] == colon else  {
             return nil
         }

--- a/Sources/NetTime/TimeOffset.swift
+++ b/Sources/NetTime/TimeOffset.swift
@@ -80,7 +80,18 @@ extension TimeOffset {
         self.init(rfc3339String: string.description)!
     }
 
-    init?(asciiValues: [Int8]) {
+    /// Create an `Offset` from an offset segement of an [RFC 3339][] timestamp.
+    /// Initialization will fail if the input does not comply with the format
+    /// specified in [RFC 3339][].
+    ///
+    /// [RFC 3339]: https://tools.ietf.org/html/rfc3339
+    ///
+    /// - Parameter rfc3339String: The offset potion of a timestamp conforming
+    ///                            to the format specified in RFC 3339. The
+    ///                            content should be the same as argument of
+    ///                            `init(rfc3339String:)`. Terminating `0` value
+    ///                            from C strings should be excluded.
+    public init?(asciiValues: [CChar]) {
         if asciiValues.count == 1,
             let first = asciiValues.first,
             first == z || first == Z


### PR DESCRIPTION
These initializers are more efficent in case UTF8 string is already unboxed from
a String. Exposing them makes `NetTime` more suitable to use as part of a larger
parser.