### PR TITLE
Fix DYLIB_INSTALL_NAME_BASE

### DIFF
--- a/NetTime.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/NetTime.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Resources/xcconfigs/UniversalFramework_Framework.xcconfig
+++ b/Resources/xcconfigs/UniversalFramework_Framework.xcconfig
@@ -33,3 +33,4 @@ ENABLE_BITCODE[sdk=appletv*]                  = YES
 
 INFOPLIST_FILE = Resources/Info.plist
 PRODUCT_BUNDLE_IDENTIFIER = ca.duan.NetTime
+DYLIB_INSTALL_NAME_BASE = @rpath


### PR DESCRIPTION
Apparently, Xcode fallback to an absolute path /Library/Frameworks for
this value. So if user choose to embed this framework, it won't be
there, therefore user's app won't launch.